### PR TITLE
Pass options to GHC to support cabal sandboxes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Documentation is on the hackage page: https://hackage.haskell.org/package/haskell-docs
+
+Or view the raw cabal file: [haskell-docs.cabal](haskell-docs.cabal)

--- a/haskell-docs.cabal
+++ b/haskell-docs.cabal
@@ -7,10 +7,16 @@ description:         Given a module name and a name, it will find and display
                      .
                      /EXAMPLE USAGE/
                      .
-                     > $ haskell-docs Data.List.Split split
+                     > $ haskell-docs getdoc Data.List.Split split
                      > Split a list according to the given splitting strategy. This is
                      >  how to "run" a Splitter that has been built using the other
                      >  combinators.
+                     .
+                     Options to GHC (for example to specify the package database for a cabal
+                     sandbox) may be passed using '-g':
+                     .
+                     > $ haskell-docs getdoc -g '-no-user-package-db' -g '-package-db /somewhere/.cabal-sandbox/x86_64-linux-ghc-7.6.3-packages.conf.d' Safe findJust
+                     > findJust op = fromJust . find op
                      .
                      /INSTALLATION/
                      .


### PR DESCRIPTION
I have the `safe` package installed in a sandbox, not in the
main user cabal directory, so this fails as expected:

```
$ haskell-docs getdoc Safe findJust
Couldn't find that module. Suggestions are forthcoming.
```

With my commit we can pass the package database options using `-g`
in a similar way to ghc-mod:

```
$ haskell-docs getdoc -g '-no-user-package-db' -g '-package-db /home/carlo/foo/.cabal-sandbox/x86_64-linux-ghc-7.6.3-packages.conf.d' Safe findJust
findJust op = fromJust . find op
```
