### PR TITLE
Pass options to GHC to support cabal sandboxes (using optparse-applicative).

### DIFF
--- a/haskell-docs.cabal
+++ b/haskell-docs.cabal
@@ -59,14 +59,16 @@ library
                        ghc-paths,
                        haddock >= 2.9 && < 2.15,
                        containers,
-                       monad-loops
+                       monad-loops,
+                       optparse-applicative
 
 executable haskell-docs
   hs-source-dirs:      src/main
   main-is:             Main.hs
   build-depends:       base > 4 && < 5,
                        ghc > 7.2 && < 7.9,
-                       haskell-docs
+                       haskell-docs,
+                       optparse-applicative
 
 source-repository head
   type:        git


### PR DESCRIPTION
I have the `safe` package installed in a sandbox, not in the
main user cabal directory, so this will fail:

```
$ haskell-docs Safe findJust
```

With my commit we can pass the package database options using `-g`:

```
$ haskell-docs -g '-no-user-package-db' -g '-package-db /home/carlo/foo/.cabal-sandbox/x86_64-linux-ghc-7.6.3-packages.conf.d' Safe findJust
findJust :: forall a. (a -> Bool) -> [a] -> a
findJust op = fromJust . find op
```
