### PR TITLE
Pass GHC --package-db options to Cabal query

### DIFF
--- a/src/Haskell/Docs/Haddock.hs
+++ b/src/Haskell/Docs/Haddock.hs
@@ -32,11 +32,12 @@ import           Packages
 
 -- | Search a name in the given module.
 searchIdent
-  :: Maybe PackageConfig
+  :: [String]
+  -> Maybe PackageConfig
   -> Identifier
   -> Ghc (Either DocsException [IdentDoc])
-searchIdent mprevious name =
-  do packages <- fmap (filterPrevious mprevious) (liftIO getAllPackages)
+searchIdent gs mprevious name =
+  do packages <- fmap (filterPrevious mprevious) (liftIO $ getAllPackages gs)
      searchInPackages packages
                       Nothing
                       name

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -28,12 +28,12 @@ main =
 
 -- | Do the printing.
 app :: [String] -> IO ()
-app (extract -> x@(gs,ms,as,ss)) =
-  do if ms
+app (extract -> x@(gs,ms,as,ss)) = do
+    if ms
         then case as of
-               [name]     -> searchAndPrintModules (Identifier name)
-               [_,name,_] -> searchAndPrintModules (Identifier name)
-               [_,name]   -> searchAndPrintModules (Identifier name)
+               [name]     -> searchAndPrintModules gs (Identifier name)
+               [_,name,_] -> searchAndPrintModules gs (Identifier name)
+               [_,name]   -> searchAndPrintModules gs (Identifier name)
         else withInitializedPackages
                gs
                (\packages ->
@@ -41,6 +41,7 @@ app (extract -> x@(gs,ms,as,ss)) =
                     (case as of
                        [name] ->
                          searchAndPrintDoc packages
+                                           gs
                                            ms
                                            ss
                                            Nothing
@@ -48,6 +49,7 @@ app (extract -> x@(gs,ms,as,ss)) =
                                            (Identifier name)
                        [mname,name,pname] ->
                          searchAndPrintDoc packages
+                                           gs
                                            ms
                                            ss
                                            (Just (PackageName pname))
@@ -55,6 +57,7 @@ app (extract -> x@(gs,ms,as,ss)) =
                                            (Identifier name)
                        [mname,name] ->
                          searchAndPrintDoc packages
+                                           gs
                                            ms
                                            ss
                                            Nothing
@@ -70,7 +73,7 @@ app (extract -> x@(gs,ms,as,ss)) =
 extract :: [String] -> ([String],Bool,[String],Bool)
 extract = go ([],False,[],False)
   where
-    go (gs,ms,as,ss) ("-g":arg:ys)    = go (arg:gs,ms,as,ss) ys
+    go (gs,ms,as,ss) ("--g":arg:ys)   = go (arg:gs,ms,as,ss) ys
     go (gs,ms,as,ss) ("--modules":ys) = go (gs,True,as,ss) ys
     go (gs,ms,as,ss) ("--sexp":ys)    = go (gs,ms,as,True) ys
     go (gs,ms,as,ss) (y:ys)           = go (gs,ms,y:as,ss) ys


### PR DESCRIPTION
List of issues:
1. Fix --g flag.
2. Read/Write index file with utf8 encoding to avoid IO errors.
3. Pass GHC --package-db options to Cabal query of installed packages when creating the index
