### PR TITLE
Pass GHC --package-db options to cabal queries

### DIFF
--- a/src/Haskell/Docs.hs
+++ b/src/Haskell/Docs.hs
@@ -29,13 +29,14 @@ import           MonadUtils
 
 -- -- | Print the documentation of a name in the given module.
 searchAndPrintDoc
-  :: Bool              -- ^ Print modules only.
+  :: [String]          -- ^ GHC Options
+  -> Bool              -- ^ Print modules only.
   -> Bool              -- ^ S-expression format.
   -> Maybe PackageName -- ^ Package.
   -> Maybe ModuleName  -- ^ Module name.
   -> Identifier        -- ^ Identifier.
   -> Ghc ()
-searchAndPrintDoc ms ss pname mname ident =
+searchAndPrintDoc gs ms ss pname mname ident =
   do (result,printPkg,printModule) <- search
      case result of
        Left err ->
@@ -52,7 +53,7 @@ searchAndPrintDoc ms ss pname mname ident =
           case (pname,mname) of
             (Just p,Just m) -> fmap (,False,False) (searchPackageModuleIdent Nothing p m ident)
             (Nothing,Just m) -> fmap (,True,False) (searchModuleIdent Nothing m ident)
-            _ -> fmap (,True,True) (searchIdent Nothing ident)
+            _ -> fmap (,True,True) (searchIdent gs Nothing ident)
 
 -- | Search only for identifiers and print out all modules associated.
 searchAndPrintModules :: [String] -> Identifier -> IO ()

--- a/src/Haskell/Docs/Haddock.hs
+++ b/src/Haskell/Docs/Haddock.hs
@@ -32,11 +32,12 @@ import           Packages
 
 -- | Search a name in the given module.
 searchIdent
-  :: Maybe PackageConfig
+  :: [String]
+  -> Maybe PackageConfig
   -> Identifier
   -> Ghc (Either DocsException [IdentDoc])
-searchIdent mprevious name =
-  do packages <- fmap (filterPrevious mprevious) (liftIO getAllPackages)
+searchIdent gs mprevious name =
+  do packages <- fmap (filterPrevious mprevious) (liftIO $ getAllPackages gs)
      searchInPackages packages
                       Nothing
                       name

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -42,19 +42,22 @@ app (extract -> x@(gs,ms,as,ss)) =
                (catchErrors
                   (case as of
                      [name] ->
-                       searchAndPrintDoc ms
+                       searchAndPrintDoc gs
+                                         ms
                                          ss
                                          Nothing
                                          Nothing
                                          (Identifier name)
                      [mname,name,pname] ->
-                       searchAndPrintDoc ms
+                       searchAndPrintDoc gs
+                                         ms
                                          ss
                                          (Just (PackageName pname))
                                          (Just (makeModuleName mname))
                                          (Identifier name)
                      [mname,name] ->
-                       searchAndPrintDoc ms
+                       searchAndPrintDoc gs
+                                         ms
                                          ss
                                          Nothing
                                          (Just (makeModuleName mname))

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -36,6 +36,7 @@ docs =
            []
            (\pkgs ->
               void (searchAndPrintDoc
+                      []
                       pkgs
                       False
                       False
@@ -47,6 +48,7 @@ docs =
            []
            (\pkgs ->
               void (searchAndPrintDoc
+                      []
                       pkgs
                       False
                       False
@@ -62,6 +64,7 @@ types =
            []
            (\pkgs ->
               do void (searchAndPrintDoc
+                        []
                         pkgs
                         False
                         False


### PR DESCRIPTION
Hello,
Add --package-db paths to the package stack db of the call to getInstalledPackages.

thanks
