### PR TITLE
Fix support for GHC < 7.10

### DIFF
--- a/src/Haskell/Docs/Haddock.hs
+++ b/src/Haskell/Docs/Haddock.hs
@@ -19,11 +19,11 @@ import           Data.Function
 import           Data.List
 import qualified Data.Map              as M
 import           Documentation.Haddock
-import           GHC                   hiding (verbosity)
+import           GHC
 import           GhcMonad              (liftIO)
 import           Name
-import           PackageConfig         hiding (PackageName)
-import           Packages              hiding (PackageName)
+import           PackageConfig
+import           Packages
 
 -- * Searching for ident docs
 

--- a/src/Haskell/Docs/Index.hs
+++ b/src/Haskell/Docs/Index.hs
@@ -41,7 +41,7 @@ import           System.IO
 import           System.Process           (readProcess)
 
 #if !(MIN_VERSION_base(4,8,0))
-import Data.Monoid (mappend)
+import Data.Monoid (mappend, mempty)
 #endif
 
 -- * Looking up identifiers

--- a/src/haddock/Haskell/Docs/HaddockDoc.hs
+++ b/src/haddock/Haskell/Docs/HaddockDoc.hs
@@ -4,31 +4,12 @@
 module Haskell.Docs.HaddockDoc where
 
 import           Control.Arrow
-import           Control.Exception (try,IOException)
-import           Control.Monad
-import           Control.Monad
-import           Data.Char
-import           Data.Either
-import           Data.Function
-import           Data.List
-import           Data.List
-import           Data.Map (Map)
-import qualified Data.Map as M
+import           Data.Char             (isSpace)
+import           Data.Map              (Map)
+import qualified Data.Map              as M
 import           Documentation.Haddock
-import           Documentation.Haddock
-import           GHC hiding (verbosity)
-import           GHC hiding (verbosity)
-import           GhcMonad (liftIO)
-import           GhcMonad (liftIO)
-import           Haskell.Docs.Cabal
-import           Haskell.Docs.Ghc
-import           Haskell.Docs.Ghc
-import           Haskell.Docs.Types
-import           Haskell.Docs.Types
+import           GHC                   hiding (verbosity)
 import           Name
-import           Name
-import           PackageConfig
-import           Packages
 
 -- | Render the doc.
 doc :: Doc String -> String
@@ -78,26 +59,30 @@ doc (DocHeader _) = ""
 -- | Get a mapping from names to doc string of that name from a
 -- Haddock interface.
 interfaceNameMap :: InstalledInterface -> Map String (Doc String)
-#if MIN_VERSION_haddock(2,10,0)
-interfaceNameMap iface =
-  M.fromList (map (second (fmap getOccString) . first getOccString)
-             (M.toList (instDocMap iface)))
-#else
-interfaceNameMap iface =
-  M.fromList (map (second (fmap getOccString . maybe DocEmpty id . fst) . first getOccString)
-             (M.toList (instDocMap iface)))
+interfaceNameMap = M.fromList
+                   . map (getOccString
+                          ***
+                          fmap getOccString
+#if !(MIN_VERSION_haddock(2,10,0))
+                            . maybe DocEmpty id . fst
 #endif
+                         )
+                   . M.toList
+                   . instDocMap
 
 -- | Get a mapping from names to doc string of that name from a
 -- Haddock interface.
 interfaceArgMap :: InstalledInterface -> Map String (Map Int (Doc Name))
-#if MIN_VERSION_haddock(2,10,0)
-interfaceArgMap iface =
-  M.fromList (map (first getOccString) (M.toList (instArgMap iface)))
+interfaceArgMap = M.fromList
+                  . map (
+#if !(MIN_VERSION_haddock(2,10,0))
+                          first getOccString
 #else
-interfaceArgMap iface = M.fromList (map (second (const M.empty) . first getOccString)
-                                        (M.toList (instDocMap iface)))
+                          getOccString *** const M.empty
 #endif
+                        )
+                  . M.toList
+                  . instDocMap
 
 -- | Strip redundant whitespace.
 normalize :: [Char] -> [Char]


### PR DESCRIPTION
When making the `Data.Monoid` import conditional in 7c25982 I forgot to also import `mempty`; this fixes that and also cleans the code for older versions of Haddock up a bit by removing spurious imports, etc.