### PR TITLE
Fix ambiguous type error

### DIFF
--- a/src/Haskell/Docs/Haddock.hs
+++ b/src/Haskell/Docs/Haddock.hs
@@ -9,7 +9,7 @@ module Haskell.Docs.Haddock where
 import Haskell.Docs.Cabal
 import Haskell.Docs.Ghc
 import Haskell.Docs.HaddockDoc
-import Haskell.Docs.Types
+import Haskell.Docs.Types as T
 
 import           Control.Arrow
 import           Control.Exception     (IOException, try)
@@ -60,7 +60,7 @@ searchModuleIdent mprevious mname name =
 -- | Search a name in the given module from the given package.
 searchPackageModuleIdent
   :: Maybe PackageConfig
-  -> PackageName
+  -> T.PackageName
   -> ModuleName
   -> Identifier
   -> Ghc (Either DocsException [IdentDoc])
@@ -69,7 +69,7 @@ searchPackageModuleIdent mprevious pname mname name =
      case result of
        [] -> return (Left NoFindModule)
        packages ->
-         case find ((== pname) . PackageName . showPackageName . getIdentifier) packages of
+         case find ((== pname) . T.PackageName . showPackageName . getIdentifier) packages of
            Nothing ->
              return (Left NoModulePackageCombo)
            Just package ->


### PR DESCRIPTION
Building on GHC 7.10.2 with `haddock-api 2.16.1`, `haddock-library 1.2.1` yielded the type error:

    Ambiguous occurrence ‘PackageName’
    It could refer to either ‘Haskell.Docs.Types.PackageName’,
                             imported from ‘Haskell.Docs.Types’ at src/Haskell/Docs/Haddock.hs:12:1-25
                             (and originally defined
                                at src/Haskell/Docs/Types.hs:(36,1)-(37,20))
                          or ‘Packages.PackageName’,
                             imported from ‘Packages’ at src/Haskell/Docs/Haddock.hs:26:1-25
                             (and originally defined in ‘PackageConfig’)

The intended type is `Haskell.Docs.Types.PackageName`. Resolve by explicitly qualifying the type at usage sites.